### PR TITLE
> fix  regex._METACHARS

### DIFF
--- a/docker_image/regexp.py
+++ b/docker_image/regexp.py
@@ -2,7 +2,7 @@ import regex
 
 
 def _quote_meta(s):
-    special_chars = regex._METACHARS
+    special_chars = frozenset("()[]{}?*+|^$\\.-#&~")
     escape = lambda c: r'\{}'.format(c) if c in special_chars else c
     sp = (escape(c) for c in s)
     return r''.join(sp)


### PR DESCRIPTION
引用私有变量是不安全的 regex._METACHARS 
容易引起兼容性问题。