### PR TITLE
Only look in domain for domain separator. Fixes #7

### DIFF
--- a/docker_image/reference.py
+++ b/docker_image/reference.py
@@ -162,7 +162,7 @@ class Reference(dict):
     def split_docker_domain(cls, name):
         i = name.find('/')
         domain, remainder = name[:i], name[i + 1:]
-        if i == -1 or (not cls._contains_any(name, '.:') and name[:i] != 'localhost'):
+        if i == -1 or (not cls._contains_any(name[:i], '.:') and name[:i] != 'localhost'):
             domain, remainder = DEFAULT_DOMAIN, name
 
         if domain == LEGACY_DEFAULT_DOMAIN:


### PR DESCRIPTION
The original behavior here was actually different from the [reference](https://github.com/distribution/distribution/blob/70e0022e42fd6518e23d72fb728ea735b670a27e/reference/normalize.go#L93). If you tried calling `parse_normalised_named` with a name that included a tag or digest but required a default domain to be inserted (like `bitnami/minideb:buster`, the result would be incorrect (the domain would be saved as `bitnami`). This change just brings it back in line again to match the reference (so in this example, the domain will instead be saved as `docker.io`.

This check for the presence of a defined domain name (by looking for the `.:` characters) should only happen in the portion of the string before a `/` is found - otherwise it gets tripped up when `name` contains a tag or digest (and therefore a `:` character).