### PR TITLE
feat: optimize parsing invalid chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Idea project settings
+.idea

--- a/docker_image/reference.py
+++ b/docker_image/reference.py
@@ -7,7 +7,7 @@ NAME_TOTAL_LENGTH_MAX = 255
 DEFAULT_DOMAIN = 'docker.io'
 LEGACY_DEFAULT_DOMAIN = 'index.docker.io'
 OFFICIAL_REPO_NAME = 'library'
-
+INVALID_REF_CHARS_TABLE = {ord(i): None for i in "?[]{}~!#$%^&*()+|<>,'\""}
 
 class InvalidReference(Exception):
     @classmethod
@@ -122,6 +122,8 @@ class Reference(dict):
         hostname, _ = s.split('/', 1)
         if '.' not in hostname:
             return
+        if s.translate(INVALID_REF_CHARS_TABLE) != s:
+            raise ReferenceInvalidFormat.default()
         matched = ImageRegexps.ANCHORED_HOSTNAME_REGEXP.match(hostname)
         if not matched:
             raise ReferenceInvalidFormat.default()

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -51,6 +51,7 @@ class TestReference(unittest.TestCase):
             create_test_case(input_='foo_bar.com:8080', repository='foo_bar.com', tag='8080'),
             create_test_case(input_='foo/foo_bar.com:8080', repository='foo/foo_bar.com', hostname='foo', tag='8080'),
             create_test_case(input_='123.dkr.ecr.eu-west-1.amazonaws.com:lol/abc:d', err=reference.ReferenceInvalidFormat),
+            create_test_case(input_='docker.artifactory.us.foo.mycompany.com/bar/node?18', err=reference.ReferenceInvalidFormat),
         ]
 
         for tc in test_cases:
@@ -159,6 +160,7 @@ class TestNormalize(unittest.TestCase):
             "docker.io/docker/Docker",
             "docker.io/docker///docker",
             "1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
+            "docker.artifactory.us.foo.mycompany.com/bar/node?18"
         ]
         for name in valid_repo_names:
             ref = reference.Reference.parse_normalized_named(name)


### PR DESCRIPTION
Image refs with many and long subdomains that have invalid characters in the image reference cause the regex engine to get bogged down and could become a regular expression denial of service attack.

For example `docker.artifactory.us.foo.mycompany.com/bar/node?18` takes >4mins to parse and return as an invalid reference. With the updates in this change set the whole test set runs in 2ms.