### PR TITLE
Add Apache-2.0 license to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(
     description="Parse docker image as distribution does.",
     url='https://github.com/realityone/docker-image-py',
     packages=['docker_image'],
+    license="Apache-2.0",
+    classifiers = [
+        "License :: OSI Approved :: Apache Software License",
+    ],
     install_requires=install_requires,
     zip_safe=False,
 )


### PR DESCRIPTION
Adding the license in package metadata and in the list of [package classifiers](https://pypi.org/classifiers/).

This is helpful for automated tools checking the license of packages, because the classifiers are a well-defined list, and tend to be well respected. This is contrary to the license metadata (which PyNaCl populates with Apache-2.0 already), where the values used in various packages seems be all over the place.

Don't hesitate to align this PR to the actual project licence if needed.